### PR TITLE
TECH-251: Filtering exit codes of zero

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -182,6 +182,17 @@ def filter_message_from_slack(message):
         return True
       if re.match("Scaling activity initiated by \(deployment ecs-svc\/[0-9]+\)", message.get('detail', {}).get('stoppedReason', '')):
         return True
+      code = []
+      for key in message['detail']['containers']:
+        if 'exitCode' in key:
+          code.append( {"exitCode": key['exitCode'] })
+      if code:
+        for key in code:
+          if key['exitCode'] != 0:
+            return False
+          else:
+            continue
+        return True
     elif message.get('source', "") == "aws.iot":
       if message.get('detail', {}).get('eventName', '') in ["AttachPrincipalPolicy", "CreateTopicRule", "AttachThingPrincipal", "UpdateCertificate", "SearchIndex"]:
         return True


### PR DESCRIPTION
Filtering out any events that contain 'exitCode' in any containers. If exists, make a list of all of them since there can be multiple containers to look into and/or container may have none, report for non-zero, else filter from slack. 