### PR TITLE
TECH-421: For messages with reason, return taskarn and containerarn

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -51,8 +51,7 @@ def ecs_notification(message, region):
     for key in message['detail']['containers']:
       if 'reason' in key:
         fields.append( { "title": "reason", "value": key['reason'], "short": True } )
-        fields.append( { "title": "taskArn", "value": key['taskArn'], "short": True } )
-        fields.append( { "title": "containerArn", "value": key['containerArn'], "short": True } )
+        fields.append( { "title": "containerName", "value": key['name'], "short": True } )
 
     if message.get("detail", {}).get('eventName', 'NOTFOUND') == 'UpdateService':
       fields.append( { "title": "eventName", "value": "UpdateService", "short": True })
@@ -62,7 +61,7 @@ def ecs_notification(message, region):
       fields.append({ "title": "desiredStatus", "value": message.get('detail', {}).get('desiredStatus', ""), "short": True })
 
     if message.get("detail", {}).get('taskDefinitionArn', 'NOTFOUND') != 'NOTFOUND':
-      fields.append({ "title": "taskDefinitionArn", "value": message.get('detail', {}).get('taskDefinitionArn', ""), "short": False })
+      fields.append({ "title": "taskArn", "value": message.get('detail', {}).get('taskArn', ""), "short": False })
 
     fields.append({ "title": "time", "value": message['time'], "short": True})
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -51,6 +51,8 @@ def ecs_notification(message, region):
     for key in message['detail']['containers']:
       if 'reason' in key:
         fields.append( { "title": "reason", "value": key['reason'], "short": True } )
+        fields.append( { "title": "taskArn", "value": key['taskArn'], "short": True } )
+        fields.append( { "title": "containerArn", "value": key['containerArn'], "short": True } )
 
     if message.get("detail", {}).get('eventName', 'NOTFOUND') == 'UpdateService':
       fields.append( { "title": "eventName", "value": "UpdateService", "short": True })


### PR DESCRIPTION
## Description 

Making some small changes as needed. 

- Add `taskArn` and `containerArn` to the slack message if there is a failure `reason` message
