### PR TITLE
TECH-802 IoT Lambda Error Edgecase

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -214,7 +214,7 @@ def filter_message_from_slack(message):
             continue
         return True
     elif message.get('source', "") == "aws.iot":
-      if message.get('detail', {}).get('eventName', '') in ["AttachPrincipalPolicy", "CreateTopicRule", "AttachThingPrincipal", "UpdateCertificate", "SearchIndex"]:
+      if message.get('detail', {}).get('eventName', '') in ["AttachPrincipalPolicy", "CreateTopicRule", "AttachThingPrincipal", "UpdateCertificate", "SearchIndex", "RegisterCertificate"]:
         return True
     elif message.get('Event Source', "") in ["db-instance", "db-security-group", "db-parameter-group", "db-snapshot", "db-cluster", "db-cluster-snapshot"]:
       if message.get('Event Message', '') in ["Finished DB Instance backup", "Backing up DB instance", "Automated snapshot created", "Creating automated snapshot"]:
@@ -247,10 +247,12 @@ def notify_slack(subject, message, region):
 
     if "source" in message and filter_message_from_slack(message):
         print("filtering message, not posting to slack")
+        print(message)
         return
 
     if "Event Source" in message and filter_message_from_slack(message):
         print("filtering message, not posting to slack")
+        print(message)
         return
 
     # pprint.pprint(message)


### PR DESCRIPTION
## Description
Were getting Lambda function errors for the following:
`'NoneType' object has no attribute 'get': AttributeError Traceback (most recent call last): File "/var/task/notify_slack.py", line 302, in lambda_handler notify_slack(subject, message, region) File "/var/task/notify_slack.py", line 282, in notify_slack notification = iot_notification(message, region) File "/var/task/notify_slack.py", line 159, in iot_notification if message.get("detail", {}).get('requestParameters', {}).get('parameters', {}).get('AWS::IoT::Certificate::CommonName', "NOTFOUND") != 'NOTFOUND': AttributeError: 'NoneType' object has no attribute 'get'`

The error triggered by this key (`\"requestParameters\":null,` apart of the `RegisterCertificate ` event) having a null value instead of a dict.



## Testing

Ran the script locally to verify the message causing the issue was working fine
![Screen Shot 2021-05-28 at 4 02 33 PM](https://user-images.githubusercontent.com/84341324/120049236-364b3a00-bfce-11eb-9867-0f4b7cc621d2.png)

