### PR TITLE
BUGFIX: fix lambda errors from if statement changes

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -298,10 +298,6 @@ def notify_slack(subject, message, region):
             notification = rds_notification(message, region)
             payload['text'] = "AWS RDS notification - " + message["detail-type"]
             payload['attachments'].append(notification)
-        elif (message['Event Source'] in ["db-instance", "db-security-group", "db-parameter-group", "db-snapshot", "db-cluster", "db-cluster-snapshot"]):
-            notification = rds_event_subscription_notification(message, region)
-            payload['text'] = "AWS RDS notification - " + message["Event Message"]
-            payload['attachments'].append(notification)
         elif (message['source'] == "aws.iam"):
             notification = iam_notification(message, region)
             payload['text'] = "AWS IAM notification - " + message["detail-type"]
@@ -317,6 +313,10 @@ def notify_slack(subject, message, region):
         else:
             payload['text'] = "AWS notification"
             payload['attachments'].append(default_notification(subject, message))
+    elif ("Event Source" in message and message['Event Source'] in ["db-instance", "db-security-group", "db-parameter-group", "db-snapshot", "db-cluster", "db-cluster-snapshot"]):
+        notification = rds_event_subscription_notification(message, region)
+        payload['text'] = "AWS RDS notification - " + message["Event Message"]
+        payload['attachments'].append(notification)
     elif "Origin" in message:
         asgstates = ['Launching', 'Terminating']
         if (message.get('AutoScalingGroupName', "") != "") and (any(state in message.get('Description', "") for state in asgstates)):


### PR DESCRIPTION
## Description 

@magreenbaum Noticed there were some error messages showing in the DEV account for [infrastructure-notifications](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Finfrastructure-notifications/log-events/2021$252F06$252F25$252F$255B$2524LATEST$255D1c1dc53b1cb4461db5afa33984958521) and [deployment-notifications](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdeployment-notifications/log-events/2021$252F06$252F25$252F$255B$2524LATEST$255D0d6c9429f2d742a59f5887133ce03973)

My last PR #15 accidentally added the previous "Event Source" statement within the parent `elif "source" in message` without the check if `"Event Source" in message` causing these error messages since "Event Source" does not exist in these messages.

```
'Event Source': KeyError
Traceback (most recent call last):
  File "/var/task/notify_slack.py", line 349, in lambda_handler
    notify_slack(subject, message, region)
  File "/var/task/notify_slack.py", line 301, in notify_slack
    elif (message['Event Source'] in ["db-instance", "db-security-group", "db-parameter-group", "db-snapshot", "db-cluster", "db-cluster-snapshot"]):
KeyError: 'Event Source'
```



* Moved 'Event Source' statement out of the wrong if statement and made
  it its own again.