### PR TITLE
TECH: Excluding CreateServiceLinkedRole

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -200,7 +200,7 @@ def default_notification(subject, message):
         }
 
 def filter_message_from_slack(message):
-    if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails"]:
+    if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails", "CreateServiceLinkedRole"]:
       return True
     elif message.get('source', "") == "aws.rds":
       if message.get('detail', {}).get('Message', '').startswith("Snapshot succeeded"):


### PR DESCRIPTION
We are having a lot of noise from this particular event so we should probably exclude it. We can view these events using other methods. 

Probably best to do it this way since this is a public facing repository. 