### PR TITLE
TECH-2075: add ecr notification

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -24,9 +24,9 @@ def ecr_notification(message, region):
         "fields": [
             { "title": "Status", "value": message.get('detail', {}).get('scan-status', ""), "short": True },
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
-            { "title": "Tags", "value": message['image-tags'][0], "short": True },
+            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', []), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": message['finding-severity-counts'], "short": True }
+            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}), "short": True }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -17,16 +17,16 @@ def decrypt(encrypted_url):
         logging.exception("Failed to decrypt URL with KMS")
 
 def ecr_notification(message, region):
-    state = 'danger' if message.get("detail", {}).get('scan-status', 'FAILED') else 'good'
+    state = 'danger' if message.get("detail", {}).get('scan-status', "") == 'FAILED' else 'good'
     return {
         "color": state,
         "fallback": "ECR {} event".format(message['detail']),
         "fields": [
             { "title": "Status", "value": message.get('detail', {}).get('scan-status', ""), "short": True },
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
-            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', ""), "short": True },
+            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', []), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', ""), "short": True }
+            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}), "short": True }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -30,7 +30,7 @@ def ecr_notification(message, region):
             { "title": "HIGH", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', ""), "short": True },
             {
                 "title": "Link to Scan Results",
-                "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['Account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
+                "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
                 "short": False
             }
         ]

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -24,9 +24,9 @@ def ecr_notification(message, region):
         "fields": [
             { "title": "Status", "value": message.get('detail', {}).get('scan-status', ""), "short": True },
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
-            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', []), "short": True },
+            { "title": "Tags", "value": message['image-tags'][0], "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}), "short": True }
+            { "title": "Findings", "value": message['finding-severity-counts'], "short": True }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -24,9 +24,9 @@ def ecr_notification(message, region):
         "fields": [
             { "title": "Status", "value": message.get('detail', {}).get('scan-status', ""), "short": True },
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
-            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', []), "short": True },
+            { "title": "Tags", "value": ",".join(message.get('detail', {}).get('image-tags', [])), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}), "short": True }
+            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}) }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -26,11 +26,11 @@ def ecr_notification(message, region):
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
             { "title": "Tags", "value": ",".join(message.get('detail', {}).get('image-tags', [])), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "CRITICAL Vulnerability", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', ""), "short": True },
-            { "title": "HIGH Vulnerability", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', ""), "short": True },
+            { "title": "CRITICAL", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', ""), "short": True },
+            { "title": "HIGH", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', ""), "short": True },
             {
                 "title": "Link to Scan Results",
-                "value": "console.aws.amazon.com/ecr/repositories/private/" + message['Account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
+                "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['Account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
                 "short": False
             }
         ]
@@ -222,13 +222,6 @@ def default_notification(subject, message):
 def filter_message_from_slack(message):
     if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails", "CreateServiceLinkedRole"]:
       return True
-    elif message.get('source', "") == "aws.ecr":
-      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != "":
-        return False
-      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != "":
-        return False
-      else:
-        return True
     elif message.get('source', "") == "aws.rds":
       if message.get('detail', {}).get('Message', '').startswith("Snapshot succeeded"):
         return True

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -30,7 +30,7 @@ def ecr_notification(message, region):
             { "title": "HIGH", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', ""), "short": True },
             {
                 "title": "Link to Scan Results",
-                "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
+                "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image/" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
                 "short": False
             }
         ]

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -27,7 +27,7 @@ def ecr_notification(message, region):
             { "title": "Tags", "value": ",".join(message.get('detail', {}).get('image-tags', [])), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
             { "title": "CRITICAL", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', ""), "short": True },
-            { "title": "HIGH", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', ""), "short": True },
+            { "title": "HIGH", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "0"), "short": True },
             {
                 "title": "Link to Scan Results",
                 "value": "https://console.aws.amazon.com/ecr/repositories/private/" + message['account'] + "/" + message.get('detail', {}).get('repository-name', "") + "/image/" + message.get('detail', {}).get('image-digest', "") + "/scan-results/?region=" + region,
@@ -223,7 +223,7 @@ def filter_message_from_slack(message):
     if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails", "CreateServiceLinkedRole"]:
       return True
     elif message.get('source', "") == "aws.ecr":
-      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != 0:
+      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "0") != 0:
         return False
       else:
         return True

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -17,7 +17,9 @@ def decrypt(encrypted_url):
         logging.exception("Failed to decrypt URL with KMS")
 
 def ecr_notification(message, region):
-    state = 'danger' if message.get("detail", {}).get('scan-status', "") == 'FAILED' else 'good'
+    state = 'danger' if message.get('detail', {}).get('scan-status', "") == 'FAILED' else 'good'
+    findings = message.get('detail', {}).get('finding-severity-counts', {})
+    list = list(findings.items())
     return {
         "color": state,
         "fallback": "ECR {} event".format(message['detail']),
@@ -26,7 +28,7 @@ def ecr_notification(message, region):
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
             { "title": "Tags", "value": ",".join(message.get('detail', {}).get('image-tags', [])), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', {}) }
+            { "title": "Findings", "value": ",".join(list) }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -223,7 +223,7 @@ def filter_message_from_slack(message):
     if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails", "CreateServiceLinkedRole"]:
       return True
     elif message.get('source', "") == "aws.ecr":
-      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "0") != 0:
+      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', 0) != 0:
         return False
       else:
         return True

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -225,8 +225,6 @@ def filter_message_from_slack(message):
     elif message.get('source', "") == "aws.ecr":
       if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != 0:
         return False
-      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != 0:
-        return False
       else:
         return True
     elif message.get('source', "") == "aws.rds":

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -224,11 +224,11 @@ def filter_message_from_slack(message):
       return True
     elif message.get('source', "") == "aws.ecr":
       if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != 0:
-        return True
-      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != 0:
-        return True
-      else:
         return False
+      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != 0:
+        return False
+      else:
+        return True
     elif message.get('source', "") == "aws.rds":
       if message.get('detail', {}).get('Message', '').startswith("Snapshot succeeded"):
         return True

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -223,9 +223,9 @@ def filter_message_from_slack(message):
     if message.get('source', "") == "aws.iam" and message.get('detail', {}).get('eventName', '') in ["GenerateCredentialReport", "GenerateServiceLastAccessedDetails", "CreateServiceLinkedRole"]:
       return True
     elif message.get('source', "") == "aws.ecr":
-      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != 0:
+      if message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', "") != "":
         return False
-      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != 0:
+      elif message.get('detail', {}).get('finding-severity-counts', {}).get('HIGH', "") != "":
         return False
       else:
         return True

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -18,8 +18,6 @@ def decrypt(encrypted_url):
 
 def ecr_notification(message, region):
     state = 'danger' if message.get('detail', {}).get('scan-status', "") == 'FAILED' else 'good'
-    findings = message.get('detail', {}).get('finding-severity-counts', {})
-    list = list(findings.items())
     return {
         "color": state,
         "fallback": "ECR {} event".format(message['detail']),
@@ -28,7 +26,7 @@ def ecr_notification(message, region):
             { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
             { "title": "Tags", "value": ",".join(message.get('detail', {}).get('image-tags', [])), "short": True },
             { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
-            { "title": "Findings", "value": ",".join(list) }
+            { "title": "CRITICAL FINDINGS", "value": message.get('detail', {}).get('finding-severity-counts', {}).get('CRITICAL', ""), "short": True }
         ]
     }        
 

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -16,6 +16,20 @@ def decrypt(encrypted_url):
     except Exception:
         logging.exception("Failed to decrypt URL with KMS")
 
+def ecr_notification(message, region):
+    state = 'danger' if message.get("detail", {}).get('scan-status', 'FAILED') else 'good'
+    return {
+        "color": state,
+        "fallback": "ECR {} event".format(message['detail']),
+        "fields": [
+            { "title": "Status", "value": message.get('detail', {}).get('scan-status', ""), "short": True },
+            { "title": "Repo", "value": message.get('detail', {}).get('repository-name', ""), "short": True },
+            { "title": "Tags", "value": message.get('detail', {}).get('image-tags', ""), "short": True },
+            { "title": "SHA", "value": message.get('detail', {}).get('image-digest', ""), "short": True },
+            { "title": "Findings", "value": message.get('detail', {}).get('finding-severity-counts', ""), "short": True }
+        ]
+    }        
+
 def asg_notification(message, regions):
     state = 'danger' if message.get("StatusCode", "") == 'Failed' else 'good'
     return {
@@ -297,6 +311,10 @@ def notify_slack(subject, message, region):
         if (message['source'] == "aws.ecs"):
             notification = ecs_notification(message, region)
             payload['text'] = "AWS ECS notification - " + message["detail-type"]
+            payload['attachments'].append(notification)
+        elif (message['source'] == "aws.ecr"):
+            notification = ecr_notification(message, region)
+            payload['text'] = "AWS ECR notification - " + message["detail-type"]
             payload['attachments'].append(notification)
         elif (message['source'] == "aws.ec2"):
             notification = ectwo_notification(message, region)


### PR DESCRIPTION
Adds ecr_notification to script and uses it if source matches `aws.ecr` so that we can process ECR Image Scan Results.

This is only sending messages to slack if `CRITICAL` or `HIGH` vulnerabilities are found.  We can adjust that to just `CRITICAL` if `HIGH` is too noisy or undesired.  The message includes a link to the scan results.

Example message
<img width="661" alt="Screen Shot 2022-06-14 at 1 21 23 PM" src="https://user-images.githubusercontent.com/54445269/173681478-6f95696f-4e33-4b5b-8da4-42e603516ebf.png">

