### PR TITLE
TECH-2198 BUGFIX Attribtue error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ terraform.tfvars
 functions/*.zip
 *.iml
 .vscode/
+.idea/

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -34,7 +34,7 @@ def ecr_notification(message, region):
                 "short": False
             }
         ]
-    }        
+    }
 
 def asg_notification(message, regions):
     state = 'danger' if message.get("StatusCode", "") == 'Failed' else 'good'
@@ -264,7 +264,7 @@ def filter_message_from_slack(message):
             continue
         return True
     elif message.get('source', "") == "aws.iot":
-      if message.get('detail', {}).get('eventName', '') in ["AttachPrincipalPolicy", "CreateTopicRule", "AttachThingPrincipal", "UpdateCertificate", "SearchIndex", "RegisterCertificate"]:
+      if message.get('detail', {}).get('eventName', '') in ["AttachPrincipalPolicy", "CreateTopicRule", "AttachThingPrincipal", "UpdateCertificate", "SearchIndex", "RegisterCertificate", "RegisterCertificateWithoutCA"]:
         return True
     elif message.get('Event Source', "") in ["db-instance", "db-security-group", "db-parameter-group", "db-snapshot", "db-cluster", "db-cluster-snapshot"]:
       if message.get('Event Message', '') in ["Finished DB Instance backup", "Backing up DB instance", "Automated snapshot created", "Creating automated snapshot", "Creating manual snapshot", "Manual snapshot created", "Deleted manual snapshot"]:


### PR DESCRIPTION
## Description

Our  CloudWatch Alarm "lambda-errors-infrastructure-notifications" has been triggering due aws IoT events `RegisterCertificateWithoutCA` where the `requestParameters` in the event has a value of `null` but we call `get()` which throws an attribute error `[ERROR] AttributeError: 'NoneType' object has no attribute 'get'` we also do not need these messages in our `#aws-events` from my understanding so filtering these made sense.

Lambda Errors: https://app.datadoghq.com/logs?query=source%3Alambda%20status%3Aerror&agg_q=%40host&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice%2C%40detail.jobName&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1658762520000&to_ts=1658776920000&live=false

AWS IoT messages triggering the errors: https://app.datadoghq.com/logs?query=%40Sns.TopicArn%3A%22arn%3Aaws%3Asns%3Aus-east-1%3A007020296906%3Ainfrastructure-notifications%22%20%40source%3Aaws.iot%20%22%5C%22requestParameters%5C%22%3Anull%22&agg_q=%40host&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice%2C%40detail.jobName&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1658762535480&to_ts=1658776935480&live=false
 