### PR TITLE
TECH-2017 Format Glue DMS events

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -204,7 +204,7 @@ def dms_notification(message, region):
     if message.get('detail', {}).get('resourceLink', "") != "":
       fields.append( { "title": "link", "value": '<{}|resource link>'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
-        "mrkdwn_in": ["fields"],
+        "mrkdwn_in": [],
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),
         "fields": fields

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -204,7 +204,7 @@ def dms_notification(message, region):
     if message.get('detail', {}).get('resourceLink', "") != "":
       fields.append( { "title": "link", "value": '<{}|resource link>'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
-        "mrkdwn_in": [],
+        "mrkdwn_in": ["fallback"],
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),
         "fields": fields

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -385,6 +385,14 @@ def notify_slack(subject, message, region):
             notification = iam_notification(message, region)
             payload['text'] = "AWS IAM notification - " + message["detail-type"]
             payload['attachments'].append(notification)
+        elif (message['source'] == "aws.dms"):
+            notification = dms_notification(message, region)
+            payload['text'] = "AWS DMS notification - " + message["detail-type"]
+            payload['attachments'].append(notification)
+        elif (message['source'] == "aws.glue"):
+            notification = glue_notification(message, region)
+            payload['text'] = "AWS Glue notification - " + message["detail-type"]
+            payload['attachments'].append(notification)
         elif (message['source'] == "aws.iot"):
             notification = iot_notification(message, region)
             payload['text'] = "AWS Iot notification - " + message["detail-type"]

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -202,7 +202,7 @@ def dms_notification(message, region):
     if message.get('detail', {}).get('type', "") == 'REPLICATION_TASK':
       fields.append( { "title": "task arn", "value": message.get('resources', [])[0], "short": True } )
     if message.get('detail', {}).get('resourceLink', "") != "":
-      fields.append( { "title": "link", "value": '< {} | resource link >'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
+      fields.append( { "title": "link", "value": '<{}|resource link>'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -204,6 +204,7 @@ def dms_notification(message, region):
     if message.get('detail', {}).get('resourceLink', "") != "":
       fields.append( { "title": "link", "value": '<{}|resource link>'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
+        "mrkdwn_in": ["fields"],
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),
         "fields": fields

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -175,6 +175,38 @@ def rds_event_subscription_notification(message, region):
             ]
         }
 
+def glue_notification(message, region):
+    state = 'danger' if message.get('detail', {}).get('state', "") in ['FAILED', 'TIMEOUT'] else 'good'
+    fields = []
+    fields.append( { "title": "account", "value": message.get('account', ""), "short": True } )
+    if message.get('detail', {}).get('jobName', "") != "":
+      fields.append( { "title": "job", "value": message.get('detail', {}).get('jobName', ""), "short": True } )
+      fields.append( { "title": "job run", "value": message.get('detail', {}).get('jobRunId', ""), "short": True } )
+    if message.get('detail', {}).get('state', "") != "":
+      fields.append( { "title": "state", "value": message.get('detail', {}).get('state', ""), "short": True } )
+    if message.get('detail', {}).get('message', "") != "":
+      fields.append( { "title": "message", "value": message.get('detail', {}).get('message', ""), "short": True } )
+    return {
+        "color": state,
+        "fallback": "Glue {} event".format(message['detail']),
+        "fields": fields
+    }
+
+def dms_notification(message, region):
+
+    state = 'danger' if message.get('detail', {}).get('eventType', "") in ['REPLICATION_TASK_STOPPED'] else 'good'
+    fields = []
+    fields.append( { "title": "account", "value": message.get('account', ""), "short": True } )
+    fields.append( { "title": "message", "value": message.get('detail', {}).get('detailMessage', ""), "short": True } )
+    fields.append( { "title": "category", "value": message.get('detail', {}).get('category', ""), "short": True } )
+    if message.get('detail', {}).get('resourceLink', "") != "":
+      fields.append( { "title": "link", "value": message.get('detail', {}).get('resourceLink', ""), "short": True } )
+    return {
+        "color": state,
+        "fallback": "DMS {} event".format(message['detail']),
+        "fields": fields
+    }
+
 def iam_notification(message, region):
     return {
             "color": 'good',

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -199,8 +199,10 @@ def dms_notification(message, region):
     fields.append( { "title": "account", "value": message.get('account', ""), "short": True } )
     fields.append( { "title": "message", "value": message.get('detail', {}).get('detailMessage', ""), "short": True } )
     fields.append( { "title": "category", "value": message.get('detail', {}).get('category', ""), "short": True } )
+    if message.get('detail', {}).get('type', "") == 'REPLICATION_TASK':
+      fields.append( { "title": "task arn", "value": message.get('resources', [])[0], "short": True } )
     if message.get('detail', {}).get('resourceLink', "") != "":
-      fields.append( { "title": "link", "value": message.get('detail', {}).get('resourceLink', ""), "short": True } )
+      fields.append( { "title": "link", "value": '< {} | resource link >'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),

--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -204,7 +204,6 @@ def dms_notification(message, region):
     if message.get('detail', {}).get('resourceLink', "") != "":
       fields.append( { "title": "link", "value": '<{}|resource link>'.format(message.get('detail', {}).get('resourceLink', "")), "short": True } )
     return {
-        "mrkdwn_in": ["fallback"],
         "color": state,
         "fallback": "DMS {} event".format(message['detail']),
         "fields": fields


### PR DESCRIPTION
## Description

Adding formatting for DMS and Glue events in Slack.

## Screenshots & Tests

Applied to dev  ran some test messages, only issue I've had is the task arn for DMS events is getting formated as an emoji becaes of the `:task:` in the arn. I tried following https://api.slack.com/reference/surfaces/formatting#disabling-formatting for "secondary message attachments" in 3c20a03348ec670f6677495f03f9881340c73e85 but didn't appear to work. Though copying the arn still works fine.

![Screen Shot 2022-07-26 at 4 37 18 PM](https://user-images.githubusercontent.com/84341324/181137964-95d215d2-2d69-446c-b9bf-e3aa6cc7fa32.png)

