### PR TITLE
fix: Remove provider-determined attribute from `lifecycle.ignore_changes`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,13 +74,6 @@ resource "aws_lambda_function" "notify_slack" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [
-      # filename, # removing this as its no longer needed since the file name is realitive
-      last_modified,
-    ]
-  }
-
   tags = merge(var.tags, var.lambda_function_tags)
 
   tracing_config {


### PR DESCRIPTION
We have these warnings showing up: 

```
╷
│ Warning: Redundant ignore_changes element
│ 
│   on .terraform/modules/<module_name>.notify_slack_lambda.notify_slack/main.tf line 54, in resource "aws_lambda_function" "notify_slack":
│   54: resource "aws_lambda_function" "notify_slack" {
│ 
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.
│ 
│ The attribute last_modified is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
│ 
│ (and 4 more similar warnings elsewhere)
╵
```

After this change, seeing a clean diff. For visibility, there is an open issue where others are still seeing a diff for `last_modified` but this looks to be potentially an invalid combination of arguments. Not seeing the same thing on our end. https://github.com/hashicorp/terraform-provider-aws/issues/29085 
